### PR TITLE
Add description to media stream

### DIFF
--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -128,7 +128,7 @@ func publish(peer *signal.Peer, msg proto.PublishMsg) (interface{}, *nprotoo.Err
 	if !found {
 		return nil, util.NewNpError(500, "Not found any node for islb.")
 	}
-	islb.AsyncRequest(proto.IslbOnStreamAdd, util.Map("rid", rid, "nid", nid, "uid", uid, "mid", mid, "tracks", tracks))
+	islb.AsyncRequest(proto.IslbOnStreamAdd, util.Map("rid", rid, "nid", nid, "uid", uid, "mid", mid, "tracks", tracks, "description", options.Description))
 	return result, nil
 }
 

--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -50,7 +50,7 @@ func join(peer *signal.Peer, msg proto.JoinMsg) (interface{}, *nprotoo.Error) {
 				log.Errorf("Unmarshal pub response %v", err)
 				return
 			}
-			log.Infof("IslbGetPubs: result=%v", result)
+			log.Infof("IslbGetPubs: result=%v", resMsg)
 			for _, pub := range resMsg.Pubs {
 				if pub.MID == "" {
 					continue

--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -166,7 +166,6 @@ func streamAdd(data proto.StreamAddMsg) (interface{}, *nprotoo.Error) {
 	if err != nil {
 		log.Errorf("Set: %v ", err)
 	}
-	log.Infof("!nn! - descField: %s", data.Description)
 
 	for msid, track := range data.Tracks {
 		var infos []proto.TrackInfo

--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -254,9 +254,10 @@ func getPubs(data proto.RoomInfo) (proto.GetPubResp, *nprotoo.Error) {
 			}
 		}
 		pub := proto.PubInfo{
-			MediaInfo: *info,
-			Info:      extraInfo,
-			Tracks:    tracks,
+			MediaInfo:   *info,
+			Info:        extraInfo,
+			Tracks:      tracks,
+			Description: "",
 		}
 		pubs = append(pubs, pub)
 	}

--- a/pkg/node/islb/internal.go
+++ b/pkg/node/islb/internal.go
@@ -14,6 +14,10 @@ import (
 	"github.com/pion/ion/pkg/util"
 )
 
+const (
+	descField = "description"
+)
+
 // WatchServiceNodes .
 func WatchServiceNodes(service string, state discovery.NodeStateType, node discovery.Node) {
 	id := node.ID
@@ -158,6 +162,11 @@ func streamAdd(data proto.StreamAddMsg) (interface{}, *nprotoo.Error) {
 	if err != nil {
 		log.Errorf("Set: %v ", err)
 	}
+	err = redis.HSetTTL(mkey, descField, data.Description, redisLongKeyTTL)
+	if err != nil {
+		log.Errorf("Set: %v ", err)
+	}
+	log.Infof("!nn! - descField: %s", data.Description)
 
 	for msid, track := range data.Tracks {
 		var infos []proto.TrackInfo
@@ -231,6 +240,7 @@ func getPubs(data proto.RoomInfo) (proto.GetPubResp, *nprotoo.Error) {
 			UID: info.UID,
 		}.BuildKey())
 		trackFields := redis.HGetAll(path)
+		desc := ""
 
 		tracks := make(map[string][]proto.TrackInfo)
 		for key, value := range trackFields {
@@ -241,6 +251,8 @@ func getPubs(data proto.RoomInfo) (proto.GetPubResp, *nprotoo.Error) {
 				}
 				log.Debugf("msid => %s, tracks => %v\n", msid, infos)
 				tracks[msid] = *infos
+			} else if key == descField {
+				desc = value
 			}
 		}
 
@@ -253,11 +265,12 @@ func getPubs(data proto.RoomInfo) (proto.GetPubResp, *nprotoo.Error) {
 				extraInfo = proto.ClientUserInfo{} // Needed?
 			}
 		}
+
 		pub := proto.PubInfo{
 			MediaInfo:   *info,
 			Info:        extraInfo,
 			Tracks:      tracks,
-			Description: "",
+			Description: desc,
 		}
 		pubs = append(pubs, pub)
 	}

--- a/pkg/proto/biz.go
+++ b/pkg/proto/biz.go
@@ -35,6 +35,7 @@ type PublishOptions struct {
 	Video       bool   `json:"video"`
 	Screen      bool   `json:"screen"`
 	TransportCC bool   `json:"transportCC,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type SubscribeOptions struct {
@@ -105,8 +106,9 @@ type TrickleMsg struct {
 
 type StreamAddMsg struct {
 	MediaInfo
-	Info   ClientUserInfo `json:"info"`
-	Tracks TrackMap       `json:"tracks"`
+	Info        ClientUserInfo `json:"info"`
+	Tracks      TrackMap       `json:"tracks"`
+	Description string         `json:"description,omitempty"`
 }
 
 type StreamRemoveMsg struct {

--- a/pkg/proto/islb.go
+++ b/pkg/proto/islb.go
@@ -2,8 +2,9 @@ package proto
 
 type PubInfo struct {
 	MediaInfo
-	Info   ClientUserInfo `json:"info"`
-	Tracks TrackMap       `json:"tracks"`
+	Info        ClientUserInfo `json:"info"`
+	Tracks      TrackMap       `json:"tracks"`
+	Description string         `json:"tracks,omitempty"`
 }
 
 type GetPubResp struct {

--- a/pkg/proto/islb.go
+++ b/pkg/proto/islb.go
@@ -4,7 +4,7 @@ type PubInfo struct {
 	MediaInfo
 	Info        ClientUserInfo `json:"info"`
 	Tracks      TrackMap       `json:"tracks"`
-	Description string         `json:"tracks,omitempty"`
+	Description string         `json:"description,omitempty"`
 }
 
 type GetPubResp struct {


### PR DESCRIPTION
## Description

- Added 'description' optional field to media stream. This can be used to add additional client-side information about the stream (for example mark stream as screen share). 