### PR TITLE
cb4597 -  Allow rejoining the room with different peer

### DIFF
--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -42,9 +42,10 @@ func join(peer *signal.Peer, msg proto.JoinMsg) (interface{}, *nprotoo.Error) {
 		}
 
 		oldPeer := signal.GetPeer(rid, peer.ID())
-		signal.DelPeer(rid, peer.ID())
-		oldPeer.Close()
-
+		if oldPeer != nil {
+			signal.DelPeer(rid, peer.ID())
+			oldPeer.Close()
+		}
 	}
 	log.Infof("biz.join adding new peer")
 	signal.AddPeer(rid, peer)

--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -25,19 +25,33 @@ func join(peer *signal.Peer, msg proto.JoinMsg) (interface{}, *nprotoo.Error) {
 		return nil, ridError
 	}
 
-	//already joined this room
-	if signal.HasPeer(rid, peer) {
-		return emptyMap, nil
-	}
-	signal.AddPeer(rid, peer)
-
 	islb, found := getRPCForIslb()
 	if !found {
 		return nil, util.NewNpError(500, "Not found any node for islb.")
 	}
+	uid := peer.ID()
+
+	//already joined this room
+	if signal.HasPeer(rid, peer) {
+		log.Infof("biz.join peer.ID()=%s already joined, removing old peer", peer.ID())
+		islb.AsyncRequest(proto.IslbOnStreamRemove, util.Map("rid", rid, "uid", uid))
+
+		_, err := islb.SyncRequest(proto.IslbClientOnLeave, util.Map("rid", rid, "uid", uid))
+		if err != nil {
+			log.Errorf("IslbClientOnLeave failed %v", err.Error())
+		}
+
+		oldPeer := signal.GetPeer(rid, peer.ID())
+		signal.DelPeer(rid, peer.ID())
+		oldPeer.Close()
+
+	}
+	log.Infof("biz.join adding new peer")
+	signal.AddPeer(rid, peer)
+
 	// Send join => islb
 	info := msg.Info
-	uid := peer.ID()
+
 	_, err := islb.SyncRequest(proto.IslbClientOnJoin, util.Map("rid", rid, "uid", uid, "info", info))
 	if err != nil {
 		log.Errorf("IslbClientOnJoin failed %v", err.Error())

--- a/pkg/signal/room.go
+++ b/pkg/signal/room.go
@@ -104,6 +104,15 @@ func HasPeer(rid proto.RID, peer *Peer) bool {
 	return room.GetPeer(peer.ID()) != nil
 }
 
+func GetPeer(rid proto.RID, id string) *peer.Peer {
+	log.Debugf("GetPeer rid=%s peer.ID=%s", rid, id)
+	room := getRoom(rid)
+	if room == nil {
+		return nil
+	}
+	return room.GetPeer(id)
+}
+
 func NotifyAllWithoutPeer(rid proto.RID, peer *Peer, method string, msg interface{}) {
 	log.Debugf("signal.NotifyAllWithoutPeer rid=%s peer.ID=%s method=%s msg=%v", rid, peer.ID(), method, msg)
 	room := getRoom(rid)

--- a/pkg/signal/server.go
+++ b/pkg/signal/server.go
@@ -84,6 +84,7 @@ func handler(connectionAuth conf.AuthConfig, msgHandler MsgHandler) func(w http.
 			http.Error(w, "Error upgrading socket", http.StatusBadRequest)
 			return
 		}
+		logger.Debugf("Creating new WebSocket")
 		wsTransport := transport.NewWebSocketTransport(socket)
 		wsTransport.Start()
 


### PR DESCRIPTION

## Description
Currently, we are ignoring join messages from participants who already joined the room. This is causing issues in a case where participant lost connectivity and needs to open a new WebSocket (IP address change for example). In this PR we will kick out old participant in that case,
