### PR TITLE
Handle websocket closure

### DIFF
--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -105,7 +105,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 				oldPeer := room.GetPeer(peer.ID())
 				// only remove if its the same peer. If newer peer joined before the cleanup, leave it.
 				if oldPeer == &peer.Peer {
-					if code > 1000 {
+					if code > 1000 || code == 100 {
 						msg := proto.LeaveMsg{
 							RoomInfo: proto.RoomInfo{RID: room.ID()},
 						}


### PR DESCRIPTION
When WebSocket connection is lost (for example, peer loses connectivity), protoo sends 100 error code (instead of 100x that's used on normal websocket close event). This ends up not removing the peer from the room. As a consequence, other participants see that peer spinning indefinitely. This might not be the best solution, but until better handling of reconnection is created, we shouldn't let user linger in room indefinitelly (24h). 