### PR TITLE
cb5993 Fix stale subscriptions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9/go.mod h1:2w
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwebrtc/go-protoo v0.0.0-20200602160428-0a199e23f7e0 h1:7lmqBSdb1ILwUJalqJdIoWPH0cnnQt4NshxXnVvrmx0=
 github.com/cloudwebrtc/go-protoo v0.0.0-20200602160428-0a199e23f7e0/go.mod h1:Q0DiItmsD5iCBdeID9Xu03ok8bemc78XJ+0rYATQbuQ=
+github.com/cloudwebrtc/go-protoo v0.0.0-20200926140535-79ecde67b906 h1:CXJrfUVNhSAKWnb+oSvd8MBCQJHK6+RS7jLvx2z3ba0=
 github.com/cloudwebrtc/nats-protoo v0.0.0-20200604135451-87b43396e8de h1:yPvjphU5iEeYTOOPzSwU9TNoy0nOwtv5LYMZMVtOrPY=
 github.com/cloudwebrtc/nats-protoo v0.0.0-20200604135451-87b43396e8de/go.mod h1:zwKwTqbrcBl9o2AHopHYlMh4KM3wMQHYeR6TrtoRCQ0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/pkg/node/biz/client.go
+++ b/pkg/node/biz/client.go
@@ -102,6 +102,20 @@ func leave(peer *signal.Peer, msg proto.LeaveMsg) (interface{}, *nprotoo.Error) 
 	if err != nil {
 		log.Errorf("IslbOnStreamRemove failed %v", err.Error())
 	}
+
+	// Unsubscribe from all remote streams
+	_, sfu, err := getRPCForSFU("", rid)
+	if err != nil {
+		log.Warnf("Not found any sfu node, reject: %d => %s", err.Code, err.Reason)
+		return nil, util.NewNpError(err.Code, err.Reason)
+	}
+
+	_, err = sfu.SyncRequest(proto.ClientUnSubscribe, util.Map("uid", uid))
+	if err != nil {
+		log.Warnf("unsubscribe: %d => %s", err.Code, err.Reason)
+		return nil, util.NewNpError(err.Code, err.Reason)
+	}
+
 	signal.DelPeer(rid, peer.ID())
 	return emptyMap, nil
 }
@@ -255,7 +269,7 @@ func unsubscribe(peer *signal.Peer, msg proto.UnsubscribeMsg) (interface{}, *npr
 		return nil, util.NewNpError(err.Code, err.Reason)
 	}
 
-	log.Infof("publish: result => %v", result)
+	log.Infof("unsubscribe: result => %v", result)
 	return result, nil
 }
 

--- a/pkg/rtc/rtc.go
+++ b/pkg/rtc/rtc.go
@@ -170,14 +170,14 @@ func check() {
 				CleanChannel <- id
 				log.Infof("Stat delete %v", id)
 			}
-			info += "pub: " + string(id) + "\n"
+			info += "\npub: " + string(id) + "\n"
 			subs := router.GetSubs()
 			if len(subs) < 6 {
 				for id := range subs {
-					info += fmt.Sprintf("sub: %s\n\n", id)
+					info += fmt.Sprintf("sub: %s\n", id)
 				}
 			} else {
-				info += fmt.Sprintf("subs: %d\n\n", len(subs))
+				info += fmt.Sprintf("subs: %d\n", len(subs))
 			}
 		}
 		routerLock.Unlock()

--- a/pkg/rtc/transport/webrtctransport.go
+++ b/pkg/rtc/transport/webrtctransport.go
@@ -236,9 +236,11 @@ func NewWebRTCTransport(id string, options RTCOptions) *WebRTCTransport {
 	w.pc.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		switch connectionState {
 		case webrtc.ICEConnectionStateDisconnected:
-			log.Errorf("webrtc ice disconnected")
+			log.Errorf("webrtc ice disconnected id=%v", id)
+			w.alive = false
+			w.shutdownChan <- id
 		case webrtc.ICEConnectionStateFailed:
-			log.Errorf("webrtc ice failed")
+			log.Errorf("webrtc ice failed id=%v", id)
 			w.alive = false
 			w.shutdownChan <- id
 		}

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -105,7 +105,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 				oldPeer := room.GetPeer(peer.ID())
 				// only remove if its the same peer. If newer peer joined before the cleanup, leave it.
 				if oldPeer == &peer.Peer {
-					if code > 1000 || code == 100 {
+					if code > 1000 {
 						msg := proto.LeaveMsg{
 							RoomInfo: proto.RoomInfo{RID: room.ID()},
 						}

--- a/pkg/signal/handle.go
+++ b/pkg/signal/handle.go
@@ -105,7 +105,7 @@ func in(transport *transport.WebSocketTransport, request *http.Request) {
 				oldPeer := room.GetPeer(peer.ID())
 				// only remove if its the same peer. If newer peer joined before the cleanup, leave it.
 				if oldPeer == &peer.Peer {
-					if code > 1000 {
+					if code > 1000 || code == 100 {
 						msg := proto.LeaveMsg{
 							RoomInfo: proto.RoomInfo{RID: room.ID()},
 						}


### PR DESCRIPTION
Description:
- Remove all subscriptions that belong to client once client leaves
- In case of reconnects, we will get new stream MID on subscriptions and won't really know that old ones are stale. However, in that case PC gets broken anyway and we can do cleanup on ICE disconnect (for some reason ICE failed never occurs). 