### PR TITLE
cb6080 Sync streams on join

### DIFF
--- a/pkg/proto/islb.go
+++ b/pkg/proto/islb.go
@@ -9,7 +9,7 @@ type PubInfo struct {
 
 type GetPubResp struct {
 	RoomInfo
-	Pubs []PubInfo
+	Pubs []PubInfo `json:"pubs,omitempty"`
 }
 
 type GetMediaParams struct {


### PR DESCRIPTION
Description: 

* Instead of grabbing all streams from the room asynchronously and notify the client one by one, synchronously grab all streams on room join and return them as result to join message. This might fix the lost media stream issues, that could have been caused when 2 people join the room at the same time. 

NOTE: first merge ION-SDK-JS [PR#6](https://github.com/cryptagon/ion-sdk-js/pull/6)